### PR TITLE
Switch CI to PlatformIO examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,14 +24,13 @@ cache:
         - "~/.platformio"
 
 env:
-    - PLATFORMIO_CI_SRC=examples/LED
-    - PLATFORMIO_CI_SRC=examples/LEDLamp
-    - PLATFORMIO_CI_SRC=examples/RGBLamp
-    - PLATFORMIO_CI_SRC=examples/TextDisplay
+    - PLATFORMIO_PROJECT_DIR=examples/PlatformIO/BME280
+    - PLATFORMIO_PROJECT_DIR=examples/PlatformIO/LED
+    - PLATFORMIO_PROJECT_DIR=examples/PlatformIO/TextDisplay
 
 install:
     - pip install -U platformio
     - platformio update
 
 script:
-    - platformio ci --project-conf examples/PlatformIO/TextDisplay/platformio.ini
+    - platformio run --project-dir $PLATFORMIO_PROJECT_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ env:
     - PLATFORMIO_PROJECT_DIR=examples/PlatformIO/TextDisplay
 
 install:
-    - pip install -U platformio
+    - pip install platformio
+    - platformio upgrade --dev
     - platformio update
 
 script:


### PR DESCRIPTION
Please update `lib_deps` in platformio.ini for the examples where libraries are missed. See http://docs.platformio.org/en/latest/projectconf/section_env_library.html#lib-deps